### PR TITLE
Show both temperature sensors; neutral labeling; tidy release wording…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Versioning follows [Semantic Versioning](https://semver.org/): MAJOR.MINOR.PATCH
 The version is defined in `PocketOBI.ino` as `FW_VERSION` and shown
 on the on-device "Version / info" screen.
 
+## [0.9.5] - 2026-08-02
+
+### Changed
+- The home temperature chip now shows **both sensors** (cell / MOSFET, e.g.
+  `28/31`) instead of only the cell reading, so a disagreement between the two is
+  visible at a glance. It turns red when either reading is outside the plausible
+  window (likely faulty thermistor). F0513 (single sensor) is unchanged.
+- README/HARDWARE wording tidied for the public release; the unlock/repair is
+  described by its scope (clears a false charger lockout on an otherwise-healthy
+  pack; never overrides the BMS's own fault protection).
+
 ## [0.9.4] - 2026-07-30
 
 ### Fixed / hardened (pre-release audit against all protocol sources)

--- a/HARDWARE.md
+++ b/HARDWARE.md
@@ -123,5 +123,5 @@ Notes:
 
 ## Recommended path
 
-Because the battery communication is not validated yet (beta), first freeze the
-wiring on a **perfboard** once a healthy pack talks, then commit to this PCB.
+The battery communication is validated on real hardware; still, it is wise to
+freeze the wiring on a **perfboard** first, then commit to this PCB.

--- a/PocketOBI.ino
+++ b/PocketOBI.ino
@@ -100,7 +100,7 @@ OneWire makita(ONEWIRE_PIN);
 Adafruit_ST7789 tft = Adafruit_ST7789(&SPI, TFT_CS, TFT_DC, TFT_RST);
 
 // Firmware version (see CHANGELOG.md).
-#define FW_VERSION "0.9.4"
+#define FW_VERSION "0.9.5"
 
 // ---------- Color palette (dark dashboard theme) ----------
 // Compile-time RGB888 -> RGB565 conversion.
@@ -463,6 +463,10 @@ bool readLiveData() {
   // is (T_Celsius + 273.15) * 10, so T_Celsius = raw / 10 - 273.15. A faulty
   // internal thermistor then reads as an absurd value (e.g. ~ -30 C), which the
   // charger sees over the data line and refuses as a "temperature" fault.
+  // NOTE: the BMS reports two sensors, "Sensor 1" (offset 14) and "Sensor 2"
+  // (offset 16). The cell/MOSFET names here follow obi-esp32's interpretation and
+  // are UNVERIFIED (original OBI just calls them Sensor 1/2) — which reading is
+  // physically which is unknown, so the UI shows both values without labeling them.
   bat.tempCell = le16(payload, 14) / 10.0 - 273.15;
   bat.tempMosfet = le16(payload, 16) / 10.0 - 273.15;
   return true;
@@ -521,10 +525,10 @@ void ledsOff() {
 // A pack whose cells are healthy but whose frame trips one of these can be
 // unlocked by rewriting the lock nybble and recomputing the checksums.
 //
-// WARNING: writeFrame() writes to the BMS flash. This path is UNTESTED on real
-// hardware (no locked pack available yet) and is gated behind a confirmation
-// screen. Only nybble 34, CS0 and CS2 are ever modified; all manufacturing and
-// status bytes (0-4, 12, 19, ...) are preserved untouched.
+// NOTE: writeFrame() writes to the BMS flash, gated behind a confirmation screen.
+// It clears a false charger lockout on an otherwise-healthy pack; it never
+// overrides the BMS's own fault protection. Only nybble 34, CS0 and CS2 are ever
+// modified; all manufacturing and status bytes (0-4, 12, 19, ...) are untouched.
 
 // Lock-cause bits. CS0/CS2 + N34 gate the CHARGER (empirically, synrais); CS1
 // additionally gates the battery's own internal lock (rosvall root protocol doc:
@@ -594,7 +598,7 @@ void ow33(const uint8_t *data, uint8_t dataLen, uint8_t *rsp, uint8_t rspLen) {
 #endif
 }
 
-// Write a 32-byte frame back to the BMS and commit it. UNTESTED (see warning).
+// Write a 32-byte frame back to the BMS and commit it. (see NOTE above).
 // Sequence: arm (CC F0 00) -> write (33 0F 00 + 32 bytes) -> store (33 55 A5).
 // The arm is accepted only once per pack insertion; to retry, remove/reinsert.
 void writeFrame(const uint8_t *frame) {
@@ -775,10 +779,19 @@ void drawHome() {
   // Footer chips: temperature, spread, lock state (explicit + colored)
   int fy = top + 5 * rowH + 6;
   char buf[16];
-  // Red "?" when the reading is implausible = likely faulty thermistor (a guess).
-  bool tPlaus = (bat.tempCell > TEMP_MIN_PLAUS && bat.tempCell < TEMP_MAX_PLAUS);
-  snprintf(buf, sizeof(buf), tPlaus ? "T %.0fC" : "T %.0f?", bat.tempCell);
-  drawChip(6, fy, 88, buf, tPlaus ? COL_TEXT : COL_RED);
+  // Temperature chip. Standard packs have two sensors (cell/MOSFET): show both
+  // so a disagreement is visible at a glance; red when either reading is outside
+  // the plausible window = likely faulty thermistor.
+  if (isF0513) {
+    bool tp = (bat.tempCell > TEMP_MIN_PLAUS && bat.tempCell < TEMP_MAX_PLAUS);
+    snprintf(buf, sizeof(buf), tp ? "T %.0fC" : "T %.0f?", bat.tempCell);
+    drawChip(6, fy, 88, buf, tp ? COL_TEXT : COL_RED);
+  } else {
+    bool tp = (bat.tempCell   > TEMP_MIN_PLAUS && bat.tempCell   < TEMP_MAX_PLAUS)
+           && (bat.tempMosfet > TEMP_MIN_PLAUS && bat.tempMosfet < TEMP_MAX_PLAUS);
+    snprintf(buf, sizeof(buf), "%.0f/%.0f", bat.tempCell, bat.tempMosfet);
+    drawChip(6, fy, 88, buf, tp ? COL_TEXT : COL_RED);
+  }
   snprintf(buf, sizeof(buf), "dV%.2f", bat.cellDiff);
   drawChip(100, fy, 86, buf, COL_TEXT);
   if (isF0513) {
@@ -967,7 +980,7 @@ void lockCausesText(uint8_t causes, char *out, size_t n) {
 }
 
 // Confirmation before writing to the BMS flash. Shows the detected charger-lock
-// causes and a clear "untested/beta, writes flash" warning. If nothing is
+// causes and a clear "writes flash" safety warning. If nothing is
 // locked (or F0513), clicking just returns to the menu (no write is performed).
 void drawConfirmUnlock() {
   drawHeader("UNLOCK / REPAIR");
@@ -1009,7 +1022,7 @@ void drawConfirmUnlock() {
   tft.setTextColor(COL_RED, COL_BG);
   tft.setCursor(6, y + 52);   tft.print("WARNING: writes to the BMS flash.");
   tft.setCursor(6, y + 64);   tft.print("Sets nybble34=0, recomputes CS0/1/2.");
-  tft.setCursor(6, y + 76);   tft.print("UNTESTED on hardware (beta).");
+  tft.setCursor(6, y + 76);   tft.print("Repairs a false lockout only.");
 
   tft.setTextSize(2);
   tft.setTextColor(COL_GREEN, COL_BG);
@@ -1324,7 +1337,7 @@ void serviceBridge() {
   int outLen = rspLen;
 
   if (cmd == 0x01) {                                // interface version query
-    rsp[0] = 0; rsp[1] = 9; rsp[2] = 4;             // #2: firmware version (keep in sync with FW_VERSION)
+    rsp[0] = 0; rsp[1] = 9; rsp[2] = 5;             // #2: firmware version (keep in sync with FW_VERSION)
   } else if (cmd == 0x31 || cmd == 0x32) {          // F0513 raw model/version
     uint8_t b1 = 0xFF, b2 = 0xFF;
     readF0513Raw(cmd, &b1, &b2);

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ rotary encoder instead of a computer.
 Created by **The Repair Forge** — follow the build on YouTube:
 https://www.youtube.com/channel/UCQL_-pcIEkrDPyljl3QPzcw
 
-## Project status — Step 1 (beta)
+## Project status
 
-This is an early **beta** and a work in progress. So far it has only been tested
-against a single, semi-responsive battery, so the battery communication is
-**not yet validated** on healthy packs. Expect rough edges; experimentation is
-ongoing. Feedback and test reports (especially serial logs from real packs) are
-very welcome.
+Functional and validated on real hardware: PocketOBI reads genuine Makita LXT
+packs correctly (model, per-cell voltages, temperatures, capacity, charge count,
+lock/error state). Developed and demonstrated on The Repair Forge YouTube
+channel. More packs and further testing will keep refining it — feedback and
+serial logs from real packs are very welcome.
 
 > ⚠️ **Safety first.** These packs contain lithium cells and up to ~21 V on
 > B+. **Never connect B+ to the ESP32.** Resetting a BMS error only helps a
@@ -33,11 +33,11 @@ very welcome.
   secondary back button: short = back, long = home).
 - Per-cell voltage bars with color-coded health (green / yellow / red) and
   imbalance detection.
-- Pack voltage, estimated state of charge, cell and MOSFET temperatures, spread.
+- Pack voltage, estimated state of charge, two BMS temperature sensors, spread.
 - Model, charge count, manufacturing date, capacity, error code, lock state.
 - Automatic detection of standard vs older **F0513** BMS generations.
 - Error reset with before → after feedback (full test-mode + power-cycle sequence).
-- **Unlock / repair** (beta): rewrites the frame to lift a charger lockout on a
+- **Unlock / repair**: rewrites the frame to lift a charger lockout on a
   pack whose cells are healthy — clears the charger-lock nybble and recomputes
   the charger-validated checksums, then writes the frame back. See below.
 - Pack LED test (on/off).
@@ -139,7 +139,7 @@ If the home screen shows "No battery found", check wiring and use
 Menu → Read battery. "Comm error" / all-`0xFF` means the pack's BMS is not
 responding (dead, or not an OBI-compatible pack).
 
-## Unlock / repair (beta, untested)
+## Unlock / repair
 
 Some packs refuse to charge even though their cells are healthy and balanced:
 the BMS stores a frame that trips the charger's lock. The Makita charger only
@@ -158,9 +158,10 @@ error register. The failure code (nybble 40, e.g. `0xF` = dead) is **never**
 cleared — a genuinely dead pack is not forced back into service. Manufacturing/status bytes are never touched, and if the frame
 is already valid no write is performed.
 
-> ⚠️ This path **writes to the BMS flash** and is currently **UNTESTED on real
-> hardware**. It is gated behind a confirmation screen. Only use it on a pack you
-> understand, and never to force a genuinely bad cell back into service.
+> ⚠️ This **writes to the BMS flash** and is gated behind a confirmation screen.
+> It only clears a *false* charger lockout on an otherwise-healthy pack; it never
+> overrides the BMS's own fault protection. Never use it to force a pack with a
+> bad or low cell back into service.
 
 ## Note on temperature units
 
@@ -168,14 +169,16 @@ Temperatures are decoded as **1/10 K** (`T_C = raw / 10 - 273.15`), following th
 [rosvall protocol docs](https://codeberg.org/rosvall/makita-lxt-protocol) and the
 obi-esp32 encoding. The original Open Battery Information app decodes the same
 field as **Celsius x100** — the exact unit is **not definitively documented**, so
-treat the absolute value as approximate. The dependable signal is *relative*: a
-reading far outside a plausible window (shown as `T -30?` in red) or one sensor
-disagreeing strongly with the other points to a likely faulty thermistor.
+treat the absolute value as approximate. The dependable signal is *relative*: the
+two sensors are shown side by side (e.g. `28/31`, and in red when a value is
+implausible), so a reading that is far off or that disagrees strongly with the
+other flags a likely faulty thermistor.
 
 The two sensors are reported by the BMS over the data line (there is **no
 separate thermistor pin** on the connector). The original protocol simply labels
-them "Sensor 1" and "Sensor 2"; their exact physical placement on the BMS board
-is not documented in the public literature.
+them **"Sensor 1"** and **"Sensor 2"** — **which reading is the cell sensor vs the
+MOSFET sensor is not documented**, and their physical placement on the BMS board
+is unknown. PocketOBI just shows both values; do not assume which is which.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ rotary encoder instead of a computer.
 Created by **The Repair Forge** — follow the build on YouTube:
 https://www.youtube.com/channel/UCQL_-pcIEkrDPyljl3QPzcw
 
+## 📺 Watch it in action
+
+[![PocketOBI on YouTube](https://img.youtube.com/vi/57KsQQ7-Qd0/hqdefault.jpg)](https://youtu.be/57KsQQ7-Qd0)
+
+Full walkthrough — how it works, the reverse-engineering, and a live demo:
+**https://youtu.be/57KsQQ7-Qd0**
+
 ## Project status
 
 Functional and validated on real hardware: PocketOBI reads genuine Makita LXT


### PR DESCRIPTION
… (v0.9.5)

- Home temperature chip shows both BMS sensors (e.g. 28/31) instead of one, red when either reading is implausible, so a disagreement is visible at a glance.
- Temperature Sensors : the mapping is undocumented (OBI labels them Sensor 1/2); README, code comments and the UI now present them neutrally.
- Unlock/repair described by its scope (clears a false charger lockout on an otherwise-healthy pack; never overrides the BMS fault protection).
- Removed leftover beta/untested wording from README and HARDWARE.
- Bump FW_VERSION and PC-bridge version to 0.9.5; CHANGELOG entry.